### PR TITLE
feat(core): Save rkrd runs and diff them

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,29 +1,72 @@
 package main
 
 import (
-	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"regexp"
+	"sort"
+	"strconv"
 
+	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
 )
 
 // working name rkrd
 
-var (
-	listeningPort = flag.String("port", "8080", "port for rkrd to listen on")
-	outputFile    = flag.String("out", "", "output file location")
-)
-
 func main() {
-	flag.Parse()
+	app := cli.NewApp()
 
-	if len(*listeningPort) == 0 {
-		logrus.Error("must provide a valid listening port")
+	app.Commands = []cli.Command{
+		{
+			Name:  "cleanup",
+			Usage: "delete all rkrdr files",
+			Action: func(c *cli.Context) error {
+				return cleanupRkrdrFiles()
+			},
+		},
+		{
+			Name:    "diff",
+			Aliases: []string{"d"},
+			Usage:   "diff two rkrdr diffs",
+			Action: func(c *cli.Context) error {
+				args := c.Args()
+				if len(args) != 2 {
+					logrus.Error("must provide two rkrdr files to diff")
+					os.Exit(1)
+				}
+
+				return diff(args[0], args[1])
+			},
+		},
+		{
+			Name:    "proxy",
+			Aliases: []string{"p"},
+			Usage:   "run rkrd proxy",
+			Action: func(c *cli.Context) error {
+				runProxy("8080")
+				return nil
+			},
+		},
+	}
+
+	sort.Sort(cli.FlagsByName(app.Flags))
+	sort.Sort(cli.CommandsByName(app.Commands))
+
+	if err := app.Run(os.Args); err != nil {
+		logrus.Error(err)
+		os.Exit(1)
+	}
+}
+
+func runProxy(listeningPort string) {
+	if len(listeningPort) == 0 {
+		logrus.Error("must provide listening port")
 		os.Exit(1)
 	}
 
-	addr := fmt.Sprintf(":%s", *listeningPort)
+	addr := fmt.Sprintf(":%s", listeningPort)
 	rkrd := NewRkrd(addr)
 	if err := rkrd.Start(); err != nil {
 		logrus.Error(err)
@@ -39,4 +82,63 @@ func main() {
 
 	v := make(chan struct{})
 	<-v
+}
+
+func diff(file0, file1 string) error {
+	data0, err := ioutil.ReadFile(file0)
+	if err != nil {
+		return err
+	}
+
+	data1, err := ioutil.ReadFile(file1)
+	if err != nil {
+		return err
+	}
+
+	dmp := diffmatchpatch.New()
+
+	diffs := dmp.DiffMain(string(data0), string(data1), false)
+
+	if len(diffs) > 1 ||
+		(len(diffs) == 1 && diffs[0].Type != diffmatchpatch.DiffEqual) {
+		fmt.Println(dmp.DiffPrettyText(diffs))
+		os.Exit(1)
+	}
+	return nil
+}
+
+func cleanupRkrdrFiles() error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	files, err := ioutil.ReadDir(wd)
+	if err != nil {
+		return err
+	}
+
+	// Let's be pretty safe here.
+	rkrdrFileNameRegexp := regexp.MustCompile("rkrdr-(.*)\\.rkrdr")
+
+	for _, file := range files {
+		match := rkrdrFileNameRegexp.FindStringSubmatch(file.Name())
+		if len(match) != 2 {
+			// Not a match, keep looking.
+			continue
+		}
+
+		if _, err := strconv.Atoi(match[1]); err != nil {
+			// Not a valid digit so skip it.
+			continue
+		}
+
+		// If we get here, for now, we assume that this is a valid
+		// rkrdr file.
+		if err := os.Remove(file.Name()); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/rkrd.go
+++ b/rkrd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/alicebob/miniredis"
@@ -52,4 +53,20 @@ func (r *rkrd) HandleConnection() error {
 	}
 
 	return nil
+}
+
+type RecordInfo struct {
+	Ctr  uint64
+	Addr string
+	Dir  string
+	Msg  string
+}
+
+func (r *RecordInfo) String() string {
+	return fmt.Sprintf(
+		"ctr=%d dir=%q msg=%q",
+		r.Ctr,
+		r.Dir,
+		r.Msg,
+	)
 }

--- a/rkrdr.go
+++ b/rkrdr.go
@@ -2,35 +2,76 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/alicebob/miniredis"
 	"github.com/sirupsen/logrus"
 )
 
+type SyncBool struct {
+	val bool
+	m   *sync.Mutex
+}
+
+func newSyncBool(val bool) *SyncBool {
+	return &SyncBool{val: val}
+}
+func (s *SyncBool) get() bool {
+	s.m.Lock()
+	defer s.m.Unlock()
+	return s.val
+}
+
+func (s *SyncBool) set(val bool) {
+	s.m.Lock()
+	s.val = val
+	s.m.Unlock()
+}
+
 type Rkrdr interface {
 	Run() error
+	Record(r *RecordInfo) error
+	NextSeqNum() uint64
 }
 
 type rkrdr struct {
 	userConn  net.Conn
 	miniredis *miniredis.Miniredis
+
+	seqNum    uint64
+	closed    *SyncBool
+	closeChan chan struct{}
+
+	outFile *os.File
 }
+
+const NUM_RKRDR_CHILDREN = 4
 
 func NewRkrdr(c net.Conn, m *miniredis.Miniredis) Rkrdr {
 	return &rkrdr{
 		userConn:  c,
 		miniredis: m,
+
+		closed:    newSyncBool(false),
+		closeChan: make(chan struct{}, NUM_RKRDR_CHILDREN),
 	}
 }
 
 func (r *rkrdr) Run() error {
-	fmt.Println(r)
-	fmt.Println(r.miniredis)
 	redisConn, err := net.Dial("tcp", r.miniredis.Addr())
 	if err != nil {
+		return err
+	}
+
+	fileName := fmt.Sprintf("rkrdr-%d.rkrdr", time.Now().Unix())
+	if r.outFile, err = os.Create(fileName); err != nil {
 		return err
 	}
 
@@ -38,29 +79,77 @@ func (r *rkrdr) Run() error {
 	toRedis := io.MultiWriter(redisConn, toRedisPR)
 	go func() {
 		for {
-			io.Copy(toRedis, r.userConn)
+			if _, err := io.Copy(toRedis, r.userConn); err != nil {
+				logrus.Info(err)
+			}
 		}
+		r.closed.set(true)
+		r.closeChan <- struct{}{}
 	}()
 
 	toUserPR, toUserPW := net.Pipe()
 	toUser := io.MultiWriter(r.userConn, toUserPR)
 	go func() {
 		for {
-			io.Copy(toUser, redisConn)
+			if _, err := io.Copy(toUser, redisConn); err != nil {
+				logrus.Info(err)
+			}
+			fmt.Println("yolo")
 		}
+		r.closed.set(true)
+		r.closeChan <- struct{}{}
 	}()
 
 	addr := r.userConn.RemoteAddr().String()
-	go recordContent(toRedisPW, addr, true)
-	go recordContent(toUserPW, addr, false)
+	go func() {
+		recordContent(toRedisPW, addr, true, r)
+		r.closed.set(true)
+		r.closeChan <- struct{}{}
+	}()
+	go func() {
+		recordContent(toUserPW, addr, false, r)
+		r.closed.set(true)
+		r.closeChan <- struct{}{}
+	}()
 	return nil
 }
 
-func recordContent(r io.Reader, addr string, isRedisClient bool) {
+func (r *rkrdr) NextSeqNum() uint64 {
+	return atomic.AddUint64(&r.seqNum, 1)
+}
+
+const RKRDR_CLOSE_TIMEOUT = time.Second * 5
+
+var ErrRkrdrCloseTimeout = errors.New("rkrdr timed out waiting to close all children")
+
+func (r *rkrdr) Close() error {
+	r.closed.set(true)
+	for i := 0; i < 4; i++ {
+		select {
+		case _ = <-r.closeChan:
+		case _ = <-time.After(RKRDR_CLOSE_TIMEOUT):
+			return ErrRkrdrCloseTimeout
+		}
+	}
+
+	return r.outFile.Close()
+}
+
+func (r *rkrdr) Record(record *RecordInfo) error {
+	_, err := r.outFile.WriteString(record.String() + "\n")
+	if err != nil {
+		return err
+	}
+	return r.outFile.Sync()
+}
+
+func recordContent(r io.Reader, addr string, isRedisClient bool, rkrdr Rkrdr) {
 	bufReader := bufio.NewReader(r)
 	prefix := fmt.Sprintf("%s: %s", addr, "  to redis")
+	direction := "to"
 	if !isRedisClient {
 		prefix = fmt.Sprintf("%s: %s", addr, "from redis")
+		direction = "from"
 	}
 
 	logrus.Infof("[%s] rkrdr begun\n", prefix)
@@ -72,6 +161,14 @@ func recordContent(r io.Reader, addr string, isRedisClient bool) {
 			logrus.Errorf("[%s] exiting rkrdr\n", prefix)
 			return
 		}
-		logrus.Infof("[%s] %q\n", prefix, ra)
+		recordInfo := RecordInfo{
+			Ctr:  rkrdr.NextSeqNum(),
+			Addr: addr,
+			Dir:  direction,
+			Msg:  ra,
+		}
+		logrus.Infof("[%s] %q\n", prefix, recordInfo.String())
+		rkrdr.Record(&recordInfo)
+
 	}
 }


### PR DESCRIPTION
Add three subcommands
 - proxy:   Move core functionality under proxy command and store run data.
 - diff:    Support diffing rkrd run files.
 - cleanup: (for dev/testing) Utility command for cleaning up extraneous rkrd
            run files.

BREAKING CHANGE: The proxy server functionality is now under the (p)roxy
subcommand.